### PR TITLE
Improve dark mode

### DIFF
--- a/screens/Home/index.tsx
+++ b/screens/Home/index.tsx
@@ -4,10 +4,9 @@ import { StyleSheet, FlatList } from 'react-native'
 import { Card, Paragraph } from 'react-native-paper'
 import Screen from '../../components/Screen'
 
-import { Text } from '../../components/Themed'
+import { Text, useThemeColor } from '../../components/Themed'
 import Colors from '../../constants/Colors'
 import { meditations, MeditationItem } from '../../data/meditations'
-import useColorScheme from '../../hooks/useColorScheme'
 import { HomeParamList } from '../../types'
 
 interface Props {
@@ -15,7 +14,7 @@ interface Props {
 }
 
 export default function Home({ navigation }: Props) {
-  const colorScheme = useColorScheme()
+  const textColor = useThemeColor({}, 'text')
 
   const renderPopularCard = ({ item }: MeditationItem) => {
     return (
@@ -30,7 +29,7 @@ export default function Home({ navigation }: Props) {
       >
         <Card.Cover style={[styles.cardImage, styles.popularImage]} source={item.image} />
         <Card.Title
-          titleStyle={colorScheme === 'light' ? styles.lightCardTitle : styles.darkCardTitle}
+          titleStyle={[styles.cardTitle, { color: textColor }]}
           subtitleStyle={styles.cardSubtitle}
           title={item.title}
           subtitle={item.subtitle}
@@ -54,7 +53,7 @@ export default function Home({ navigation }: Props) {
       >
         <Card.Cover style={styles.cardImage} source={item.image} />
         <Card.Title
-          titleStyle={colorScheme === 'light' ? styles.lightCardTitle : styles.darkCardTitle}
+          titleStyle={[styles.cardTitle, { color: textColor }]}
           subtitleStyle={styles.cardSubtitle}
           title={item.title}
           subtitle={item.subtitle}
@@ -104,13 +103,8 @@ const styles = StyleSheet.create({
     width: 250,
     marginRight: 10,
   },
-  lightCardTitle: {
+  cardTitle: {
     fontSize: 16,
-    color: Colors.light.gray900,
-  },
-  darkCardTitle: {
-    fontSize: 16,
-    color: Colors.light.white,
   },
   cardImage: {
     height: 135,

--- a/screens/Home/index.tsx
+++ b/screens/Home/index.tsx
@@ -7,6 +7,7 @@ import Screen from '../../components/Screen'
 import { Text } from '../../components/Themed'
 import Colors from '../../constants/Colors'
 import { meditations, MeditationItem } from '../../data/meditations'
+import useColorScheme from '../../hooks/useColorScheme'
 import { HomeParamList } from '../../types'
 
 interface Props {
@@ -14,6 +15,8 @@ interface Props {
 }
 
 export default function Home({ navigation }: Props) {
+  const colorScheme = useColorScheme()
+
   const renderPopularCard = ({ item }: MeditationItem) => {
     return (
       <Card
@@ -27,7 +30,7 @@ export default function Home({ navigation }: Props) {
       >
         <Card.Cover style={[styles.cardImage, styles.popularImage]} source={item.image} />
         <Card.Title
-          titleStyle={styles.cardTitle}
+          titleStyle={colorScheme === 'light' ? styles.lightCardTitle : styles.darkCardTitle}
           subtitleStyle={styles.cardSubtitle}
           title={item.title}
           subtitle={item.subtitle}
@@ -51,7 +54,7 @@ export default function Home({ navigation }: Props) {
       >
         <Card.Cover style={styles.cardImage} source={item.image} />
         <Card.Title
-          titleStyle={styles.cardTitle}
+          titleStyle={colorScheme === 'light' ? styles.lightCardTitle : styles.darkCardTitle}
           subtitleStyle={styles.cardSubtitle}
           title={item.title}
           subtitle={item.subtitle}
@@ -101,9 +104,13 @@ const styles = StyleSheet.create({
     width: 250,
     marginRight: 10,
   },
-  cardTitle: {
+  lightCardTitle: {
     fontSize: 16,
     color: Colors.light.gray900,
+  },
+  darkCardTitle: {
+    fontSize: 16,
+    color: Colors.light.white,
   },
   cardImage: {
     height: 135,

--- a/screens/Stats/Calendar/index.tsx
+++ b/screens/Stats/Calendar/index.tsx
@@ -11,8 +11,7 @@ export default function Calendar() {
   const calendar = useAppSelector(selectCalendar)
   const white = useThemeColor({}, 'white')
   const primary = useThemeColor({}, 'primary')
-  const gray900 = useThemeColor({}, 'gray900')
-  const text = useThemeColor({}, 'text')
+  const textColor = useThemeColor({}, 'text')
   const today = dayjs().format('YYYY-MM-DD')
   const markedDates = {
     [today]: {
@@ -32,12 +31,12 @@ export default function Calendar() {
         selectedDayBackgroundColor: primary,
         selectedDayTextColor: white,
         todayTextColor: primary,
-        dayTextColor: text,
+        dayTextColor: textColor,
         textDisabledColor: '#d9e1e8',
         dotColor: primary,
         selectedDotColor: white,
-        arrowColor: gray900,
-        monthTextColor: text,
+        arrowColor: textColor,
+        monthTextColor: textColor,
         indicatorColor: 'blue',
         textDayFontWeight: '300',
         textMonthFontWeight: 'bold',


### PR DESCRIPTION
## Description

Improve dark mode styles
- [x] Dark mode text for tiles should be white
- [x] Arrows for calendar should also be white

## Ticket Link

  Closes https://github.com/heylinda/heylinda-app/issues/13

## How has this been tested?

Tested the home screen using these devices:

Pixel 4 XL API 30 - Simulator

Could not test on my physical device because of #21 

## Screenshots


![Simulator - Light Mode - Calendar](https://user-images.githubusercontent.com/35175560/127932541-ceab7633-055f-49a8-ac7a-0d2291b6e19c.png)
![Simulator - Light Mode - Card tiles](https://user-images.githubusercontent.com/35175560/127932543-b75fb63f-0a80-4e00-8c61-928c523eff2c.png)
![Simulator - Dark Mode - Calendar](https://user-images.githubusercontent.com/35175560/127932544-557036bd-d3bc-49fa-887a-854f6eb0d9a2.png)
![Simulator - Dark Mode - Card tiles](https://user-images.githubusercontent.com/35175560/127932546-2dbbc2c0-c474-421f-a01f-4edbeff32253.png)


## Checklist

- [x] Added a "Closes [issue number]" in the ticket link section
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens
