### PR TITLE
Adds a simple completed screen

### DIFF
--- a/navigation/BottomTabNavigator.tsx
+++ b/navigation/BottomTabNavigator.tsx
@@ -6,6 +6,7 @@ import { StyleSheet } from 'react-native'
 
 import Colors from '../constants/Colors'
 import useColorScheme from '../hooks/useColorScheme'
+import CompletedScreen from '../screens/Completed'
 import HomeScreen from '../screens/Home'
 import PlayScreen from '../screens/Play'
 import SettingsScreen from '../screens/Settings'
@@ -76,6 +77,18 @@ function TabOneNavigator() {
         options={{
           headerBackTitle: 'Back',
           headerTitle: 'Play',
+          headerStyle: styles.header,
+          headerTitleStyle: styles.headerTitle,
+          headerTintColor: Colors.light.white,
+        }}
+      />
+      <HomeStack.Screen
+        name="CompletedScreen"
+        component={CompletedScreen}
+        options={{
+          headerShown: false,
+          headerBackTitle: 'Back',
+          headerTitle: 'Completed',
           headerStyle: styles.header,
           headerTitleStyle: styles.headerTitle,
           headerTintColor: Colors.light.white,

--- a/screens/Completed/index.tsx
+++ b/screens/Completed/index.tsx
@@ -1,0 +1,81 @@
+import * as React from 'react'
+import { StackNavigationProp } from '@react-navigation/stack'
+import { StyleSheet } from 'react-native'
+import { AntDesign as Icon } from '@expo/vector-icons'
+import { Button } from 'react-native-paper'
+
+import { Screen, Text } from '../../components'
+import Colors from '../../constants/Colors'
+import { HomeParamList } from '../../types'
+import { Linking } from 'react-native'
+
+interface Props {
+  navigation: StackNavigationProp<HomeParamList, 'CompletedScreen'>
+}
+
+const Completed = ({ navigation }: Props) => {
+  const onPressDonate = () => {
+    Linking.openURL('https://opencollective.com/heylinda#category-CONTRIBUTE')
+  }
+  const onPressSkip = () => navigation.replace('HomeScreen')
+
+  return (
+    <Screen style={styles.screen}>
+      <Icon size={50} name="checkcircle" color={Colors.light.white} style={styles.checkMark} />
+      <Text style={styles.title}>Congratulations!</Text>
+      <Text style={styles.description}>
+        You have completed the meditation.{'\n'}Do you want to give a donation?
+      </Text>
+      <Button
+        onPress={onPressDonate}
+        style={styles.button}
+        mode="contained"
+        color={Colors.light.white}
+      >
+        Donate
+      </Button>
+      <Button
+        onPress={onPressSkip}
+        style={styles.button}
+        mode="contained"
+        color={Colors.light.white}
+      >
+        Skip
+      </Button>
+    </Screen>
+  )
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: Colors.light.primary,
+    padding: 40,
+  },
+  checkMark: {
+    marginBottom: 20,
+  },
+  title: {
+    color: Colors.light.white,
+    textAlign: 'center',
+    fontSize: 24,
+    fontWeight: '600',
+    marginBottom: 20,
+  },
+  description: {
+    color: Colors.light.white,
+    fontSize: 18,
+    textAlign: 'center',
+    lineHeight: 28,
+    marginBottom: 60,
+  },
+  button: {
+    padding: 8,
+    width: '100%',
+    marginBottom: 20,
+  },
+})
+
+export default Completed

--- a/screens/Completed/index.tsx
+++ b/screens/Completed/index.tsx
@@ -17,7 +17,7 @@ const Completed = ({ navigation }: Props) => {
   const onPressDonate = () => {
     Linking.openURL('https://opencollective.com/heylinda#category-CONTRIBUTE')
   }
-  const onPressSkip = () => navigation.replace('HomeScreen')
+  const onPressSkip = () => navigation.navigate('HomeScreen')
 
   return (
     <Screen style={styles.screen}>

--- a/screens/Play/index.tsx
+++ b/screens/Play/index.tsx
@@ -13,12 +13,14 @@ import { useMsToTime, useAppDispatch } from '../../hooks'
 import { completed } from '../../redux/meditationSlice'
 import { LoadingScreen } from '../../components'
 import { useCallback } from 'react'
+import { StackNavigationProp } from '@react-navigation/stack'
 
 type PlayRouteProp = RouteProp<HomeParamList, 'PlayScreen'>
 interface Props {
+  navigation: StackNavigationProp<HomeParamList, 'PlayScreen'>
   route: PlayRouteProp
 }
-export default function PlayScreen({ route }: Props) {
+export default function PlayScreen({ route, navigation }: Props) {
   const { id } = route.params
   const meditation = useMeditation(id)
   const [isLoadingAudio, setIsLoadingAudio] = React.useState(true)
@@ -46,10 +48,11 @@ export default function PlayScreen({ route }: Props) {
         if (playbackStatus.didJustFinish) {
           dispatch(completed(playbackStatus.durationMillis || 0))
           setIsPlaying(false)
+          navigation.replace('CompletedScreen')
         }
       }
     },
-    [dispatch]
+    [dispatch, navigation]
   )
 
   React.useEffect(() => {

--- a/types.tsx
+++ b/types.tsx
@@ -3,28 +3,30 @@
  * https://reactnavigation.org/docs/typescript/
  */
 
+export type NO_PARAMS = undefined
 export type RootStackParamList = {
-  Root: undefined
-  NotFound: undefined
+  Root: NO_PARAMS
+  NotFound: NO_PARAMS
 }
 
 export type BottomTabParamList = {
-  Home: undefined
-  Stats: undefined
-  Settings: undefined
+  Home: NO_PARAMS
+  Stats: NO_PARAMS
+  Settings: NO_PARAMS
 }
 
 export type HomeParamList = {
-  HomeScreen: undefined
+  HomeScreen: NO_PARAMS
   PlayScreen: {
     id: string
   }
+  CompletedScreen: NO_PARAMS
 }
 
 export type StatsParamList = {
-  StatsScreen: undefined
+  StatsScreen: NO_PARAMS
 }
 
 export type SettingsParamList = {
-  SettingsScreen: undefined
+  SettingsScreen: NO_PARAMS
 }


### PR DESCRIPTION
## Description

Completed screen for after a meditation is completed.
<!--
A description of what this pull request does.
-->

## Ticket Link

Closes #6 
<!--
Please link the relevant GitHub issue, e.g.

  Closes https://github.com/patio/chat-mobile/issues/XXXXX

-->

## How has this been tested?

iPhone 11 13.2.2 - Simulator

Android Honor 8x
<!--

Please describe the tests that you ran to verify your changes. e.g.

Tested the home screen using these devices:

iPhone 11 13.2.2 - Simulator

Pixel 2 API 29 - Simulator

-->

## Screenshots

![simulator_screenshot_1DD3B96D-41ED-462C-AC07-E9B9DE654A08](https://user-images.githubusercontent.com/3059371/128090617-6c8ecc37-e46f-4162-9f0d-e36f90a3c75c.png)

<!--
If the PR includes UI changes or is related to a screen, include screenshots/GIFs.
-->


## Checklist

- [x] Added a "Closes [issue number]" in the ticket link section
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens
