### PR TITLE
Hide bottom tab completed

### DIFF
--- a/navigation/AppRoutes.ts
+++ b/navigation/AppRoutes.ts
@@ -1,0 +1,13 @@
+export enum AppRoutes {
+  Root = 'Root',
+  NotFound = 'NotFound',
+  Main = 'Main',
+  CompletedScreen = 'CompletedScreen',
+  Home = 'Home',
+  Stats = 'Stats',
+  Settings = 'Settings',
+  HomeScreen = 'HomeScreen',
+  PlayScreen = 'PlayScreen',
+  StatsScreen = 'StatsScreen',
+  SettingsScreen = 'SettingsScreen',
+}

--- a/navigation/BottomTabNavigator.tsx
+++ b/navigation/BottomTabNavigator.tsx
@@ -6,12 +6,12 @@ import { StyleSheet } from 'react-native'
 
 import Colors from '../constants/Colors'
 import useColorScheme from '../hooks/useColorScheme'
-import CompletedScreen from '../screens/Completed'
 import HomeScreen from '../screens/Home'
 import PlayScreen from '../screens/Play'
 import SettingsScreen from '../screens/Settings'
 import StatsScreen from '../screens/Stats'
 import { BottomTabParamList, HomeParamList, SettingsParamList, StatsParamList } from '../types'
+import { AppRoutes } from './AppRoutes'
 
 const BottomTab = createBottomTabNavigator<BottomTabParamList>()
 
@@ -20,25 +20,25 @@ export default function BottomTabNavigator() {
 
   return (
     <BottomTab.Navigator
-      initialRouteName="Home"
+      initialRouteName={AppRoutes.Home}
       tabBarOptions={{ activeTintColor: Colors[colorScheme].tint }}
     >
       <BottomTab.Screen
-        name="Home"
+        name={AppRoutes.Home}
         component={TabOneNavigator}
         options={{
           tabBarIcon: ({ color }) => <TabBarIcon name="home" color={color} />,
         }}
       />
       <BottomTab.Screen
-        name="Stats"
+        name={AppRoutes.Stats}
         component={StatsNavigator}
         options={{
           tabBarIcon: ({ color }) => <TabBarIcon name="calendar" color={color} />,
         }}
       />
       <BottomTab.Screen
-        name="Settings"
+        name={AppRoutes.Settings}
         component={SettingsNavigator}
         options={{
           tabBarIcon: ({ color }) => <TabBarIcon name="setting" color={color} />,
@@ -62,7 +62,7 @@ function TabOneNavigator() {
   return (
     <HomeStack.Navigator>
       <HomeStack.Screen
-        name="HomeScreen"
+        name={AppRoutes.HomeScreen}
         component={HomeScreen}
         options={{
           headerTitle: 'Home',
@@ -72,23 +72,11 @@ function TabOneNavigator() {
         }}
       />
       <HomeStack.Screen
-        name="PlayScreen"
+        name={AppRoutes.PlayScreen}
         component={PlayScreen}
         options={{
           headerBackTitle: 'Back',
           headerTitle: 'Play',
-          headerStyle: styles.header,
-          headerTitleStyle: styles.headerTitle,
-          headerTintColor: Colors.light.white,
-        }}
-      />
-      <HomeStack.Screen
-        name="CompletedScreen"
-        component={CompletedScreen}
-        options={{
-          headerShown: false,
-          headerBackTitle: 'Back',
-          headerTitle: 'Completed',
           headerStyle: styles.header,
           headerTitleStyle: styles.headerTitle,
           headerTintColor: Colors.light.white,
@@ -104,7 +92,7 @@ function StatsNavigator() {
   return (
     <StatsStack.Navigator>
       <StatsStack.Screen
-        name="StatsScreen"
+        name={AppRoutes.StatsScreen}
         component={StatsScreen}
         options={{
           headerTitle: 'Stats',
@@ -122,7 +110,7 @@ function SettingsNavigator() {
   return (
     <SettingsStack.Navigator>
       <SettingsStack.Screen
-        name="SettingsScreen"
+        name={AppRoutes.SettingsScreen}
         component={SettingsScreen}
         options={{
           headerTitle: 'Settings',

--- a/navigation/MainNavigator.tsx
+++ b/navigation/MainNavigator.tsx
@@ -1,0 +1,41 @@
+import { createStackNavigator } from '@react-navigation/stack'
+import React from 'react'
+import { StyleSheet } from 'react-native'
+import BottomTabNavigator from './BottomTabNavigator'
+import CompletedScreen from '../screens/Completed'
+import Colors from '../constants/Colors'
+import { MainStackParamList } from '../types'
+import { AppRoutes } from './AppRoutes'
+
+const Stack = createStackNavigator<MainStackParamList>()
+
+export default function MainNavigator() {
+  return (
+    <Stack.Navigator screenOptions={{ headerShown: false }}>
+      <Stack.Screen name={AppRoutes.Main} component={BottomTabNavigator} />
+      <Stack.Screen
+        name={AppRoutes.CompletedScreen}
+        component={CompletedScreen}
+        options={{
+          headerShown: false,
+          headerBackTitle: 'Back',
+          headerTitle: 'Completed',
+          headerStyle: styles.header,
+          headerTitleStyle: styles.headerTitle,
+          headerTintColor: Colors.light.white,
+        }}
+      />
+    </Stack.Navigator>
+  )
+}
+
+const styles = StyleSheet.create({
+  headerTitle: {
+    fontWeight: '600',
+    color: Colors.light.white,
+    fontSize: 16,
+  },
+  header: {
+    backgroundColor: Colors.light.primary,
+  },
+})

--- a/navigation/index.tsx
+++ b/navigation/index.tsx
@@ -10,9 +10,10 @@ import { ColorSchemeName } from 'react-native'
 
 import NotFoundScreen from '../screens/NotFoundScreen'
 import { RootStackParamList } from '../types'
-import BottomTabNavigator from './BottomTabNavigator'
+import MainNavigator from './MainNavigator'
 import LinkingConfiguration from './LinkingConfiguration'
 import { StatusBar } from 'expo-status-bar'
+import { AppRoutes } from './AppRoutes'
 
 export default function Navigation({ colorScheme }: { colorScheme: ColorSchemeName }) {
   return (
@@ -33,8 +34,12 @@ const Stack = createStackNavigator<RootStackParamList>()
 function RootNavigator() {
   return (
     <Stack.Navigator screenOptions={{ headerShown: false }}>
-      <Stack.Screen name="Root" component={BottomTabNavigator} />
-      <Stack.Screen name="NotFound" component={NotFoundScreen} options={{ title: 'Oops!' }} />
+      <Stack.Screen name={AppRoutes.Root} component={MainNavigator} />
+      <Stack.Screen
+        name={AppRoutes.NotFound}
+        component={NotFoundScreen}
+        options={{ title: 'Oops!' }}
+      />
     </Stack.Navigator>
   )
 }

--- a/screens/Completed/index.tsx
+++ b/screens/Completed/index.tsx
@@ -6,13 +6,14 @@ import { Button } from 'react-native-paper'
 
 import { Screen, Text } from '../../components'
 import Colors from '../../constants/Colors'
-import { HomeParamList } from '../../types'
+import { MainStackParamList } from '../../types'
 import { Linking } from 'react-native'
 import { useAppSelector } from '../../hooks'
 import { selectTotalSessions } from '../../redux/selectors'
+import { AppRoutes } from '../../navigation/AppRoutes'
 
 interface Props {
-  navigation: StackNavigationProp<HomeParamList, 'CompletedScreen'>
+  navigation: StackNavigationProp<MainStackParamList, AppRoutes.CompletedScreen>
 }
 
 const Completed = ({ navigation }: Props) => {
@@ -20,7 +21,7 @@ const Completed = ({ navigation }: Props) => {
   const onPressDonate = () => {
     Linking.openURL('https://opencollective.com/heylinda/donate')
   }
-  const onPressSkip = () => navigation.navigate('HomeScreen')
+  const onPressSkip = () => navigation.navigate(AppRoutes.Main)
 
   return (
     <Screen style={styles.screen}>

--- a/screens/Home/index.tsx
+++ b/screens/Home/index.tsx
@@ -7,10 +7,11 @@ import Screen from '../../components/Screen'
 import { Text, useThemeColor } from '../../components/Themed'
 import Colors from '../../constants/Colors'
 import { meditations, MeditationItem } from '../../data/meditations'
+import { AppRoutes } from '../../navigation/AppRoutes'
 import { HomeParamList } from '../../types'
 
 interface Props {
-  navigation: StackNavigationProp<HomeParamList, 'HomeScreen'>
+  navigation: StackNavigationProp<HomeParamList, AppRoutes.HomeScreen>
 }
 
 export default function Home({ navigation }: Props) {
@@ -22,7 +23,7 @@ export default function Home({ navigation }: Props) {
         elevation={1}
         style={styles.card}
         onPress={() =>
-          navigation.navigate('PlayScreen', {
+          navigation.navigate(AppRoutes.PlayScreen, {
             id: item.id,
           })
         }
@@ -46,7 +47,7 @@ export default function Home({ navigation }: Props) {
       <Card
         style={styles.card}
         onPress={() =>
-          navigation.navigate('PlayScreen', {
+          navigation.navigate(AppRoutes.PlayScreen, {
             id: item.id,
           })
         }

--- a/screens/Play/index.tsx
+++ b/screens/Play/index.tsx
@@ -7,17 +7,23 @@ import Screen from '../../components/Screen'
 import { Text } from '../../components/Themed'
 import { useMeditation } from '../../hooks'
 import NotFoundScreen from '../NotFoundScreen'
-import { HomeParamList } from '../../types'
-import { RouteProp } from '@react-navigation/native'
+import { HomeParamList, MainStackParamList } from '../../types'
+import { CompositeNavigationProp, RouteProp } from '@react-navigation/native'
 import { useMsToTime, useAppDispatch } from '../../hooks'
 import { completed } from '../../redux/meditationSlice'
 import { LoadingScreen } from '../../components'
 import { useCallback } from 'react'
 import { StackNavigationProp } from '@react-navigation/stack'
+import { AppRoutes } from '../../navigation/AppRoutes'
 
-type PlayRouteProp = RouteProp<HomeParamList, 'PlayScreen'>
+type PlayRouteProp = RouteProp<HomeParamList, AppRoutes.PlayScreen>
+
+type PlayNavProp = CompositeNavigationProp<
+  StackNavigationProp<HomeParamList, AppRoutes.PlayScreen>,
+  StackNavigationProp<MainStackParamList>
+>
 interface Props {
-  navigation: StackNavigationProp<HomeParamList, 'PlayScreen'>
+  navigation: PlayNavProp
   route: PlayRouteProp
 }
 export default function PlayScreen({ route, navigation }: Props) {
@@ -48,7 +54,7 @@ export default function PlayScreen({ route, navigation }: Props) {
         if (playbackStatus.didJustFinish) {
           dispatch(completed(playbackStatus.durationMillis || 0))
           setIsPlaying(false)
-          navigation.replace('CompletedScreen')
+          navigation.replace(AppRoutes.CompletedScreen)
         }
       }
     },

--- a/types.tsx
+++ b/types.tsx
@@ -3,30 +3,36 @@
  * https://reactnavigation.org/docs/typescript/
  */
 
+import { AppRoutes } from './navigation/AppRoutes'
+
 export type NO_PARAMS = undefined
 export type RootStackParamList = {
-  Root: NO_PARAMS
-  NotFound: NO_PARAMS
+  [AppRoutes.Root]: NO_PARAMS
+  [AppRoutes.NotFound]: NO_PARAMS
+}
+
+export type MainStackParamList = {
+  [AppRoutes.Main]: NO_PARAMS
+  [AppRoutes.CompletedScreen]: NO_PARAMS
 }
 
 export type BottomTabParamList = {
-  Home: NO_PARAMS
-  Stats: NO_PARAMS
-  Settings: NO_PARAMS
+  [AppRoutes.Home]: NO_PARAMS
+  [AppRoutes.Stats]: NO_PARAMS
+  [AppRoutes.Settings]: NO_PARAMS
 }
 
 export type HomeParamList = {
-  HomeScreen: NO_PARAMS
-  PlayScreen: {
+  [AppRoutes.HomeScreen]: NO_PARAMS
+  [AppRoutes.PlayScreen]: {
     id: string
   }
-  CompletedScreen: NO_PARAMS
 }
 
 export type StatsParamList = {
-  StatsScreen: NO_PARAMS
+  [AppRoutes.StatsScreen]: NO_PARAMS
 }
 
 export type SettingsParamList = {
-  SettingsScreen: NO_PARAMS
+  [AppRoutes.SettingsScreen]: NO_PARAMS
 }


### PR DESCRIPTION
## Description

This PR will 
- create AppRoutes enum for typechecked routes throughout the apps
- Hide bottom tabs from completed screen

## Ticket Link

  Closes https://github.com/heylinda/heylinda-app/issues/37

## How has this been tested?

Tested the Completed screen using these devices:

Pixel 4 XL API 30 - Simulator

## Screenshots

(To be added)

## Checklist

- [x] Added a "Closes [issue number]" in the ticket link section
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens
