### PR TITLE
Manual entry time update fix

### DIFF
--- a/constants/Units.ts
+++ b/constants/Units.ts
@@ -1,0 +1,1 @@
+export const msPerMinute = 60000

--- a/constants/Units.ts
+++ b/constants/Units.ts
@@ -1,1 +1,1 @@
-export const msPerMinute = 60000
+export const MS_PER_MINUTE = 60000

--- a/redux/meditationSlice.ts
+++ b/redux/meditationSlice.ts
@@ -36,6 +36,7 @@ const meditationSlice = createSlice({
     ) {
       const { duration, timestamp } = action.payload
 
+      // Delete sessions with 0 duration since a single activity is used for manual
       if (duration === 0) {
         delete state.activity[timestamp]
         return

--- a/screens/Stats/Calendar/index.tsx
+++ b/screens/Stats/Calendar/index.tsx
@@ -34,6 +34,7 @@ export default function Calendar({ setManualEntryTimestamp }: Props) {
   }
 
   const onManualInput = ({ day, month, year }: DateObject) => {
+    // DateObject months go from 1 to 12, Date months go from 0 to 11
     const newTimestamp = new Date(year, month - 1, day).getTime()
 
     if (newTimestamp < Date.now()) {

--- a/screens/Stats/ManualEntry/__tests__/index.tsx
+++ b/screens/Stats/ManualEntry/__tests__/index.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { act, render } from '@testing-library/react-native'
 import ManualEntry from '..'
 import { useAppSelector as realUseAppSelector } from '../../../../hooks'
+import { msPerMinute } from '../../../../constants/Units'
 
 const DialogMock = 'Dialog' as unknown as React.FC<{ testID: string }>
 const Dialog = (props: React.PropsWithChildren<{}>) => <DialogMock testID="dialog" {...props} />
@@ -42,7 +43,7 @@ describe('tests for ManualEntry component', () => {
 
   it('should render visible with default value and enabled submit button', () => {
     useAppSelector.mockReturnValue({
-      '1': { duration: 30 },
+      '1': { duration: 30 * msPerMinute },
     })
     const { getByTestId } = render(<ManualEntry timestamp={1} onDismiss={() => {}} />)
 
@@ -50,7 +51,7 @@ describe('tests for ManualEntry component', () => {
     expect(dialog.props.visible).toBe(true)
 
     const input = getByTestId('input')
-    expect(input.props.defaultValue).toBe('30')
+    expect(input.props.defaultValue).toBe('30 *')
 
     const submitBtn = getByTestId('submit-btn')
     expect(submitBtn.props.disabled).toBe(false)

--- a/screens/Stats/ManualEntry/__tests__/index.tsx
+++ b/screens/Stats/ManualEntry/__tests__/index.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { act, render } from '@testing-library/react-native'
 import ManualEntry from '..'
 import { useAppSelector as realUseAppSelector } from '../../../../hooks'
-import { msPerMinute } from '../../../../constants/Units'
+import { MS_PER_MINUTE } from '../../../../constants/Units'
 
 const DialogMock = 'Dialog' as unknown as React.FC<{ testID: string }>
 const Dialog = (props: React.PropsWithChildren<{}>) => <DialogMock testID="dialog" {...props} />
@@ -43,7 +43,7 @@ describe('tests for ManualEntry component', () => {
 
   it('should render visible with default value and enabled submit button', () => {
     useAppSelector.mockReturnValue({
-      '1': { duration: 30 * msPerMinute },
+      '1': { duration: 30 * MS_PER_MINUTE },
     })
     const { getByTestId } = render(<ManualEntry timestamp={1} onDismiss={() => {}} />)
 
@@ -51,7 +51,7 @@ describe('tests for ManualEntry component', () => {
     expect(dialog.props.visible).toBe(true)
 
     const input = getByTestId('input')
-    expect(input.props.defaultValue).toBe('30 *')
+    expect(input.props.defaultValue).toBe('30')
 
     const submitBtn = getByTestId('submit-btn')
     expect(submitBtn.props.disabled).toBe(false)

--- a/screens/Stats/ManualEntry/index.tsx
+++ b/screens/Stats/ManualEntry/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { StyleSheet } from 'react-native'
 import { Button, Paragraph, Dialog, Portal, Provider, TextInput } from 'react-native-paper'
-import { msPerMinute } from '../../../constants/Units'
+import { MS_PER_MINUTE } from '../../../constants/Units'
 import { useAppDispatch, useAppSelector } from '../../../hooks'
 import { manualEntry } from '../../../redux/meditationSlice'
 import { selectActivity } from '../../../redux/selectors'
@@ -25,7 +25,7 @@ const ManualEntry = ({ timestamp, onDismiss }: Props) => {
 
     const newDuration = activity[timestamp]?.duration || -1
     setDuration(newDuration)
-    setDefaultValue(newDuration === -1 ? '' : Math.floor(newDuration / msPerMinute).toString())
+    setDefaultValue(newDuration === -1 ? '' : Math.floor(newDuration / MS_PER_MINUTE).toString())
   }, [activity, timestamp])
 
   const onChangeText = (text: string) => {
@@ -36,7 +36,7 @@ const ManualEntry = ({ timestamp, onDismiss }: Props) => {
       return
     }
 
-    setDuration(value * msPerMinute)
+    setDuration(value * MS_PER_MINUTE)
   }
 
   const onSubmit = () => {

--- a/screens/Stats/ManualEntry/index.tsx
+++ b/screens/Stats/ManualEntry/index.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { StyleSheet } from 'react-native'
 import { Button, Paragraph, Dialog, Portal, Provider, TextInput } from 'react-native-paper'
+import { msPerMinute } from '../../../constants/Units'
 import { useAppDispatch, useAppSelector } from '../../../hooks'
 import { manualEntry } from '../../../redux/meditationSlice'
 import { selectActivity } from '../../../redux/selectors'
@@ -9,8 +10,6 @@ interface Props {
   timestamp?: number
   onDismiss: () => void
 }
-
-const msPerMinute = 60000
 
 const ManualEntry = ({ timestamp, onDismiss }: Props) => {
   const visible = Boolean(timestamp)

--- a/screens/Stats/ManualEntry/index.tsx
+++ b/screens/Stats/ManualEntry/index.tsx
@@ -10,6 +10,8 @@ interface Props {
   onDismiss: () => void
 }
 
+const msPerMinute = 60000
+
 const ManualEntry = ({ timestamp, onDismiss }: Props) => {
   const visible = Boolean(timestamp)
   const dispatch = useAppDispatch()
@@ -24,7 +26,7 @@ const ManualEntry = ({ timestamp, onDismiss }: Props) => {
 
     const newDuration = activity[timestamp]?.duration || -1
     setDuration(newDuration)
-    setDefaultValue(newDuration === -1 ? '' : newDuration.toString())
+    setDefaultValue(newDuration === -1 ? '' : Math.floor(newDuration / msPerMinute).toString())
   }, [activity, timestamp])
 
   const onChangeText = (text: string) => {
@@ -35,7 +37,7 @@ const ManualEntry = ({ timestamp, onDismiss }: Props) => {
       return
     }
 
-    setDuration(value)
+    setDuration(value * msPerMinute)
   }
 
   const onSubmit = () => {


### PR DESCRIPTION
## Description

Adds the missing conversion from minutes to ms to the manual entry modal and comments explaining deletion and calendar date conversion.

## Ticket Link

Closes #54

## How has this been tested?

iPhone X 14.7.1

## Screenshots

![Adding](https://user-images.githubusercontent.com/609357/130365725-5492eec8-483c-476f-8026-d31970d3f3cb.png)
![Updated time](https://user-images.githubusercontent.com/609357/130365736-f9e7a019-d956-46cf-97e0-6254be916545.png)

## Checklist

- [x] Added a "Closes [issue number]" in the ticket link section
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens
