### PR TITLE
Add completed screen dark mode colors

### DIFF
--- a/constants/Colors.ts
+++ b/constants/Colors.ts
@@ -1,6 +1,7 @@
 const primary = '#463FB0'
 const purples = {
   purple900: '#4A5784',
+  purple500: '#6F69C9',
 }
 const grays = {
   white: '#fff',
@@ -20,6 +21,8 @@ export default {
     tabIconDefault: '#ccc',
     ...purples,
     ...grays,
+    completedBackground: primary,
+    completedPrimary: grays.white,
   },
   dark: {
     primary,
@@ -30,5 +33,7 @@ export default {
     ...purples,
     ...grays,
     white: grays.gray950,
+    completedBackground: grays.gray900,
+    completedPrimary: purples.purple500,
   },
 }

--- a/screens/Completed/index.tsx
+++ b/screens/Completed/index.tsx
@@ -4,7 +4,7 @@ import { StyleSheet } from 'react-native'
 import { AntDesign as Icon } from '@expo/vector-icons'
 import { Button } from 'react-native-paper'
 
-import { Screen, Text } from '../../components'
+import { Screen, Text, useThemeColor } from '../../components'
 import Colors from '../../constants/Colors'
 import { MainStackParamList } from '../../types'
 import { Linking } from 'react-native'
@@ -17,25 +17,22 @@ interface Props {
 
 const Completed = ({ navigation }: Props) => {
   const totalSessions = useAppSelector(selectTotalSessions)
+  const backgroundColor = useThemeColor({}, 'completedBackground')
+  const primaryColor = useThemeColor({}, 'completedPrimary')
   const onPressDonate = () => {
     Linking.openURL('https://opencollective.com/heylinda/donate')
   }
   const onPressSkip = () => navigation.replace('Main')
 
   return (
-    <Screen style={styles.screen}>
-      <Icon size={50} name="checkcircle" color={Colors.light.white} style={styles.checkMark} />
+    <Screen style={[styles.screen, { backgroundColor }]}>
+      <Icon size={50} name="checkcircle" color={primaryColor} style={styles.checkMark} />
       <Text style={styles.title}> Congratulations!</Text>
       <Text style={styles.description}>
         You have completed {totalSessions} meditation{totalSessions === 1 ? '' : 's'}!{'\n'}Do you
         want to give a donation?
       </Text>
-      <Button
-        onPress={onPressDonate}
-        style={styles.button}
-        mode="contained"
-        color={Colors.light.white}
-      >
+      <Button onPress={onPressDonate} style={styles.button} mode="contained" color={primaryColor}>
         Donate
       </Button>
       <Button


### PR DESCRIPTION
## Description

Adds dark mode colors to the completed screen.

## Ticket Link

Closes #38.

## How has this been tested?

Tested on an iPhone X running iOS 14.7.1.

## Screenshots

![Completed screen](https://user-images.githubusercontent.com/609357/131413779-470ebdd1-5c20-4475-aa67-d41991e930e5.png)

## Checklist

- [x] Added a "Closes [issue number]" in the ticket link section
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens
