### PR TITLE
feat: add saved bottom tab and basic screen

### DIFF
--- a/navigation/BottomTabNavigator.tsx
+++ b/navigation/BottomTabNavigator.tsx
@@ -10,6 +10,7 @@ import HomeScreen from '../screens/Home'
 import PlayScreen from '../screens/Play'
 import SettingsScreen from '../screens/Settings'
 import StatsScreen from '../screens/Stats'
+import SavedScreen from '../screens/Saved'
 import { BottomTabParamList, HomeParamList, SettingsParamList, StatsParamList } from '../types'
 
 const BottomTab = createBottomTabNavigator<BottomTabParamList>()
@@ -34,6 +35,13 @@ export default function BottomTabNavigator() {
         component={StatsNavigator}
         options={{
           tabBarIcon: ({ color }) => <TabBarIcon name="calendar" color={color} />,
+        }}
+      />
+      <BottomTab.Screen
+        name="Saved"
+        component={SavedScreen}
+        options={{
+          tabBarIcon: ({ color }) => <TabBarIcon name="hearto" color={color} />,
         }}
       />
       <BottomTab.Screen

--- a/redux/favoriteSlice.ts
+++ b/redux/favoriteSlice.ts
@@ -1,0 +1,27 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+
+export interface FavoriteState {
+  favorites: string[]
+}
+
+const initialState: FavoriteState = {
+  favorites: [],
+}
+
+// TODO: Name "favoriteSlice" is temporary, will be renamed to SavedSlice or something similar as the feature is further developed
+const favoriteSlice = createSlice({
+  name: 'favorites',
+  initialState,
+  reducers: {
+    markAsFavorite: (state, action: PayloadAction<string>) => {
+      state.favorites.push(action.payload)
+    },
+    removeFromFavorites: (state, action: PayloadAction<string>) => {
+      state.favorites = state.favorites.filter((id) => id !== action.payload)
+    },
+  },
+})
+
+export const { markAsFavorite, removeFromFavorites } = favoriteSlice.actions
+
+export default favoriteSlice.reducer

--- a/redux/rootReducer.ts
+++ b/redux/rootReducer.ts
@@ -1,8 +1,10 @@
 import { combineReducers } from '@reduxjs/toolkit'
 import meditationReducer from './meditationSlice'
+import favoriteReducer from './favoriteSlice'
 
 const rootReducer = combineReducers({
   meditation: meditationReducer,
+  favorite: favoriteReducer,
 })
 
 export default rootReducer

--- a/redux/selectors.ts
+++ b/redux/selectors.ts
@@ -48,3 +48,5 @@ export const selectStreak = (state: RootState) => {
 
   return streak
 }
+
+export const selectFavorites = (state: RootState) => state.favorite.favorites

--- a/screens/Play/PlayerControls/index.tsx
+++ b/screens/Play/PlayerControls/index.tsx
@@ -8,19 +8,23 @@ interface Props {
   positionTime: string
   durationTime: string
   isPlaying: boolean
+  isFavorite: boolean
   pause: () => void
   play: () => void
   replay: () => void
   forward: () => void
+  toggleFavorite: () => void
 }
 export default function PlayerControls({
   positionTime,
   durationTime,
   isPlaying,
+  isFavorite,
   pause,
   play,
   replay,
   forward,
+  toggleFavorite,
 }: Props) {
   return (
     <View style={styles.controls}>
@@ -33,7 +37,11 @@ export default function PlayerControls({
       )}
       <PlayerIcon name="forward-10" onPress={forward} size={30} />
       <Text>{durationTime}</Text>
-      <PlayerIcon name="favorite-outline" onPress={() => {}} size={30} />
+      {isFavorite ? (
+        <PlayerIcon name="favorite" onPress={toggleFavorite} size={30} />
+      ) : (
+        <PlayerIcon name="favorite-outline" onPress={toggleFavorite} size={30} />
+      )}
     </View>
   )
 }

--- a/screens/Play/PlayerControls/index.tsx
+++ b/screens/Play/PlayerControls/index.tsx
@@ -33,6 +33,7 @@ export default function PlayerControls({
       )}
       <PlayerIcon name="forward-10" onPress={forward} size={30} />
       <Text>{durationTime}</Text>
+      <PlayerIcon name="favorite-outline" onPress={() => {}} size={30} />
     </View>
   )
 }

--- a/screens/Play/index.tsx
+++ b/screens/Play/index.tsx
@@ -15,6 +15,8 @@ import { LoadingScreen } from '../../components'
 import { useCallback } from 'react'
 import { StackNavigationProp } from '@react-navigation/stack'
 import { selectFilePaths } from '../../redux/selectors'
+import { markAsFavorite, removeFromFavorites } from '../../redux/favoriteSlice'
+import { selectFavorites } from '../../redux/selectors'
 
 type PlayRouteProp = RouteProp<HomeParamList, 'PlayScreen'>
 
@@ -39,6 +41,7 @@ export default function PlayScreen({ route, navigation }: Props) {
   const dispatch = useAppDispatch()
   const uri = meditation?.uri || ''
   const filepaths = useAppSelector(selectFilePaths)
+  const favorites = useAppSelector(selectFavorites)
 
   const onPlaybackStatusUpdate = useCallback(
     (playbackStatus: AVPlaybackStatus) => {
@@ -130,7 +133,16 @@ export default function PlayScreen({ route, navigation }: Props) {
     return <NotFoundScreen />
   }
 
+  const toggleFavorite = () => {
+    if (isFavorite) {
+      dispatch(removeFromFavorites(meditation.id))
+    } else {
+      dispatch(markAsFavorite(meditation.id))
+    }
+  }
+
   const { title, subtitle, image } = meditation
+  const isFavorite = favorites.includes(meditation.id)
 
   if (isLoadingAudio) {
     return <LoadingScreen loading={isLoadingAudio} />
@@ -143,12 +155,14 @@ export default function PlayScreen({ route, navigation }: Props) {
       <Text style={styles.subtitle}>{subtitle}</Text>
       <PlayerControls
         isPlaying={isPlaying}
+        isFavorite={isFavorite}
         play={play}
         pause={pause}
         replay={replay}
         forward={forward}
         positionTime={positionTime}
         durationTime={durationTime}
+        toggleFavorite={toggleFavorite}
       />
     </Screen>
   )

--- a/screens/Saved/index.tsx
+++ b/screens/Saved/index.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react'
+import { StyleSheet } from 'react-native'
+import Screen from '../../components/Screen'
+
+import { Text } from '../../components/Themed'
+
+interface Props {}
+
+export default function Saved({}: Props) {
+  return (
+    <Screen scroll>
+      <Text style={styles.title}>ANXIETY</Text>
+      <Text style={styles.title}>SLEEP</Text>
+    </Screen>
+  )
+}
+
+const styles = StyleSheet.create({
+  title: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    marginBottom: 19,
+  },
+})

--- a/types.tsx
+++ b/types.tsx
@@ -17,6 +17,7 @@ export type MainStackParamList = {
 export type BottomTabParamList = {
   Home: NO_PARAMS
   Stats: NO_PARAMS
+  Saved: NO_PARAMS
   Settings: NO_PARAMS
 }
 


### PR DESCRIPTION
## Description

- Allow the users to create custom lists and add meditations to lists
- Add a bottom tab called "Saved"
- Add "Saved" Screen where users can browser their saved meditations and play them again

## Ticket Link

Closes https://github.com/heylinda/heylinda-app/issues/42

## How has this been tested?

<!--

Please describe the tests that you ran to verify your changes. e.g.

Tested the home screen using these devices:

iPhone 11 13.2.2 - Simulator

Pixel 2 API 29 - Simulator

-->

## Screenshots

<!--
If the PR includes UI changes or is related to a screen, include screenshots/GIFs.
-->


## Checklist

- [x] Added a "Closes [issue number]" in the ticket link section
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens
