### PR TITLE
chore(typescript): upgrade typescript 4.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "husky": "^7.0.0",
     "jest-expo": "^42.0.0",
     "lint-staged": "^11.1.1",
-    "typescript": "~4.3.5"
+    "typescript": "~4.4.3"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -8747,10 +8747,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@~4.3.5:
-  version "4.3.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
-  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
+typescript@~4.4.3:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.3.tgz#bdc5407caa2b109efd4f82fe130656f977a29324"
+  integrity sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==
 
 ua-parser-js@^0.7.18:
   version "0.7.28"


### PR DESCRIPTION
## Description

<!--
A description of what this pull request does.
-->
This bumps TS version from 4.3.5 -> 4.4.3

## Ticket Link
Closes https://github.com/heylinda/heylinda-app/issues/105
<!--
Please link the relevant GitHub issue, e.g.

  Closes https://github.com/patio/chat-mobile/issues/XXXXX

-->

## How has this been tested?
I ran `yarn tsc` to check if any types were broken.
<!--

Please describe the tests that you ran to verify your changes. e.g.

Tested the home screen using these devices:

iPhone 11 13.2.2 - Simulator

Pixel 2 API 29 - Simulator

-->

## Screenshots

<!--
If the PR includes UI changes or is related to a screen, include screenshots/GIFs.
-->


## Checklist

- [x] Added a "Closes [issue number]" in the ticket link section
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens
