### PR TITLE
fix(NavigationBar): updates navigation bar color to reflect system color theme (dark/light)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -12,10 +12,12 @@ import Navigation from './navigation'
 import { store, persistor } from './redux/store'
 import { PersistGate } from 'redux-persist/integration/react'
 import { gestureHandlerRootHOC } from 'react-native-gesture-handler'
+import useSetNavigationBarColor from './hooks/useSetNavigationBarColor'
 
 const App = () => {
   const isLoadingComplete = useCachedResources()
   const colorScheme = useColorScheme()
+  useSetNavigationBarColor()
 
   if (!isLoadingComplete) {
     return null

--- a/constants/Colors.ts
+++ b/constants/Colors.ts
@@ -1,15 +1,16 @@
-const primary = '#463FB0'
+const primary = '#463FB0' // rgb(70, 63, 176)
 const purples = {
-  purple900: '#4A5784',
-  purple500: '#6F69C9',
+  purple900: '#4A5784', // rgb(74, 87, 132)
+  purple500: '#6F69C9', // rgb(111, 105, 201)
 }
 const grays = {
-  white: '#fff',
-  gray100: '#F2F2F2',
-  gray800: '#5D5D5D',
-  gray900: '#333333',
-  gray950: '#1D1E1E',
-  black: '#000',
+  white: '#fff', // rgb(255, 255, 255)
+  gray100: '#F2F2F2', // rgb(242, 242, 242)
+  gray800: '#5D5D5D', // rgb(93, 93, 93)
+  gray900: '#333333', // rgb(51, 51, 51)
+  gray950: '#1e1e1e', //rgb(30, 30, 30)
+  gray975: '#121212', // rgb(18, 18, 18)
+  black: '#000', // rgb(0, 0, 0)
 }
 
 export default {
@@ -23,6 +24,7 @@ export default {
     ...grays,
     completedBackground: primary,
     completedPrimary: grays.white,
+    navBarBackground: grays.white,
   },
   dark: {
     primary,
@@ -35,5 +37,6 @@ export default {
     white: grays.gray950,
     completedBackground: grays.gray900,
     completedPrimary: purples.purple500,
+    navBarBackground: grays.gray975,
   },
 }

--- a/hooks/useSetNavigationBarColor.ts
+++ b/hooks/useSetNavigationBarColor.ts
@@ -1,0 +1,11 @@
+import * as React from 'react'
+import * as NavigationBar from 'expo-navigation-bar'
+import { useThemeColor } from '../components'
+
+export default function useSetNavigationBarColor() {
+  const backgroundColor = useThemeColor({}, 'navBarBackground')
+
+  React.useEffect(() => {
+    NavigationBar.setBackgroundColorAsync(backgroundColor)
+  }, [backgroundColor])
+}

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "expo-file-system": "~13.1.2",
     "expo-font": "~10.0.4",
     "expo-linking": "~3.0.0",
+    "expo-navigation-bar": "~1.1.1",
     "expo-splash-screen": "~0.14.1",
     "expo-status-bar": "~1.2.0",
     "expo-web-browser": "~10.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7057,6 +7057,15 @@ expo-modules-core@0.6.5:
     compare-versions "^3.4.0"
     invariant "^2.2.4"
 
+expo-navigation-bar@~1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/expo-navigation-bar/-/expo-navigation-bar-1.1.2.tgz#1caddf41b3fd7652796db933ffe59a1ab0ed658c"
+  integrity sha512-6TEmFArrCazRKrhQrWho1sBEXiFBP+7MIcAeZ5wEB+QEb7ZkYmC+JKFfZl3oz9VWD7nnhgcLRgFE9XL0n74Fow==
+  dependencies:
+    "@expo/config-plugins" "^4.0.2"
+    "@react-native/normalize-color" "^2.0.0"
+    debug "^4.3.2"
+
 expo-pwa@0.0.95:
   version "0.0.95"
   resolved "https://registry.yarnpkg.com/expo-pwa/-/expo-pwa-0.0.95.tgz#a0f3756903dee81e86a928c3c8064d33eabb6a25"


### PR DESCRIPTION
## Description

Updates navigation bar color to reflect system color theme 
<!--
A description of what this pull request does.
-->

## Ticket Link

No ticket.
<!--
Please link the relevant GitHub issue, e.g.

  Closes https://github.com/patio/chat-mobile/issues/XXXXX

-->

## How has this been tested?

Android and iOS 12
<!--

Please describe the tests that you ran to verify your changes. e.g.

Tested the home screen using these devices:

iPhone 11 13.2.2 - Simulator

Pixel 2 API 29 - Simulator

-->

## Screenshots

![272040680_891961264809112_8920914607509098817_n](https://user-images.githubusercontent.com/3059371/152606341-f579165f-b595-44d4-ab8c-f0963838f2a1.jpg)
![272077984_365176705608562_7427611761849477506_n](https://user-images.githubusercontent.com/3059371/152606344-c3349708-d12c-46b2-83c6-bb9f73c3d630.jpg)

<!--
If the PR includes UI changes or is related to a screen, include screenshots/GIFs.
-->


## Checklist

- [ ] Added a "Closes [issue number]" in the ticket link section
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens
