### PR TITLE
feat: adds amplitude analytics tracking

### DIFF
--- a/navigation/index.tsx
+++ b/navigation/index.tsx
@@ -1,8 +1,3 @@
-/**
- * If you are not familiar with React Navigation, check out the "Fundamentals" guide:
- * https://reactnavigation.org/docs/getting-started
- *
- */
 import {
   NavigationContainer,
   DefaultTheme,
@@ -18,16 +13,26 @@ import { RootStackParamList } from '../types'
 import MainNavigator from './MainNavigator'
 import LinkingConfiguration from './LinkingConfiguration'
 import { StatusBar } from 'expo-status-bar'
-import { PageHit } from 'expo-analytics'
-import analytics from '../utils/analytics'
+import { initializeAnalytics, logEvent } from '../utils/analytics'
 
 export default function Navigation({ colorScheme }: { colorScheme: ColorSchemeName }) {
   const navigationContainerRef = React.useRef<NavigationContainerRef<any>>(null)
 
+  React.useEffect(() => {
+    async function initialize() {
+      try {
+        await initializeAnalytics()
+      } catch (e) {
+        console.error(e)
+      }
+    }
+    initialize()
+  }, [])
+
   const handleNavigationStateChange = async () => {
     const currentRouteName = navigationContainerRef?.current?.getCurrentRoute()?.name
     try {
-      await analytics.hit(new PageHit(currentRouteName || 'Unknown'))
+      await logEvent(`Screen:${currentRouteName}` || 'Screen:Unknown')
     } catch (e) {
       console.error(e)
     }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "dayjs": "^1.10.6",
     "expo": "^44.0.0",
     "expo-analytics": "^1.0.18",
+    "expo-analytics-amplitude": "~11.1.0",
     "expo-asset": "~8.4.6",
     "expo-av": "~10.2.0",
     "expo-blur": "~11.0.0",

--- a/utils/analytics.ts
+++ b/utils/analytics.ts
@@ -1,5 +1,9 @@
-import { Analytics } from 'expo-analytics'
+import * as Amplitude from 'expo-analytics-amplitude'
 
-const analytics = new Analytics('UA-219496436-2')
+export const initializeAnalytics = async () => {
+  await Amplitude.initializeAsync('c53c4e54414340dc1e6feeb7fd95293c')
+}
 
-export default analytics
+export const logEvent = async (eventName: string) => {
+  await Amplitude.logEventAsync(eventName)
+}

--- a/utils/analytics.ts
+++ b/utils/analytics.ts
@@ -1,9 +1,14 @@
 import * as Amplitude from 'expo-analytics-amplitude'
+import { Platform } from 'react-native'
 
 export const initializeAnalytics = async () => {
-  await Amplitude.initializeAsync('c53c4e54414340dc1e6feeb7fd95293c')
+  if (Platform.OS !== 'web') {
+    await Amplitude.initializeAsync('c53c4e54414340dc1e6feeb7fd95293c')
+  }
 }
 
 export const logEvent = async (eventName: string) => {
-  await Amplitude.logEventAsync(eventName)
+  if (Platform.OS !== 'web') {
+    await Amplitude.logEventAsync(eventName)
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6906,6 +6906,11 @@ expect@^26.6.2:
     jest-message-util "^26.6.2"
     jest-regex-util "^26.0.0"
 
+expo-analytics-amplitude@~11.1.0:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/expo-analytics-amplitude/-/expo-analytics-amplitude-11.1.1.tgz#6fd49e6f54e2ef0768989186eff7603b44f45b41"
+  integrity sha512-ppwOm+r7y1h2Y+GvMKaaSUYEOHB3gaP4wzM5Fp8d77iC6P8zcFh7d17a1QBsZ2n3nvsup8Rd1enbW294yOa4qw==
+
 expo-analytics@^1.0.18:
   version "1.0.18"
   resolved "https://registry.yarnpkg.com/expo-analytics/-/expo-analytics-1.0.18.tgz#7379d25482140f154a473f523f4a0155defad922"


### PR DESCRIPTION
## Description

Removes google analytics tracking in favour of amplitude
<!--
A description of what this pull request does.
-->

## Ticket Link

No ticket.
<!--
Please link the relevant GitHub issue, e.g.

  Closes https://github.com/patio/chat-mobile/issues/XXXXX

-->

## How has this been tested?

- iOS
- Android
<!--

Please describe the tests that you ran to verify your changes. e.g.

Tested the home screen using these devices:

iPhone 11 13.2.2 - Simulator

Pixel 2 API 29 - Simulator

-->

## Screenshots

No UI changes.
<!--
If the PR includes UI changes or is related to a screen, include screenshots/GIFs.
-->


## Checklist

- [ ] Added a "Closes [issue number]" in the ticket link section
- [ ] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens
