### PR TITLE
fixed display of hour plus long tracks

### DIFF
--- a/hooks/useMsToTime.ts
+++ b/hooks/useMsToTime.ts
@@ -8,8 +8,15 @@ export function useMsToTime(s: number) {
   const secs = s % 60
   s = (s - secs) / 60
   const mins = s % 60
+  s = (s - mins) / 60
+  const hour = s
+  const hourString = formatToString(hour)
   const minsString = formatToString(mins)
   const secsString = formatToString(secs)
 
-  return minsString + ':' + secsString
+  if (s == 0) {
+    return minsString + ':' + secsString
+  } else {
+    return hourString + ':' + minsString + ':' + secsString
+  }
 }


### PR DESCRIPTION
## Description

If a meditation track was greater than 59:59 it would not display the hours. It would just leave them out. 

## Ticket Link

N/A

## How has this been tested?

Tested the play screen using these devices:

iPhone 13 - Simulator

## Screenshots

<img width="300" alt="Screen Shot 2022-06-24 at 12 12 59 AM" src="https://user-images.githubusercontent.com/1031728/175461032-fca43405-1098-4b77-aa0a-b690c0723aee.png">

## Checklist

- [ ] Added a "Closes [issue number]" in the ticket link section
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens
